### PR TITLE
fix ErrorException for undefined variable character_id

### DIFF
--- a/src/resources/views/corporation/mining/ledger.blade.php
+++ b/src/resources/views/corporation/mining/ledger.blade.php
@@ -53,7 +53,7 @@
                         </td>
                         <td>
                             <span class="character-id-to-main-character"
-                                  data-character-id="{{$character_id}}">Unknown</span>
+                                  data-character-id="{{ $entry->character_id }}">Unknown</span>
                         </td>
                         <td class="text-right" data-order="{{ $entry->quantity }}">{{ number($entry->quantity) }}</td>
                         <td class="text-right" data-order="{{ $entry->volumes }}">{{ number($entry->volumes) }} m3</td>


### PR DESCRIPTION
The corporation mining ledger view contains a reference to the variable $character_id for the main character column, which should be $entry->character_id.